### PR TITLE
회원 정보 조회, 회원 정보 수정, 탈퇴, 휴면 계정 처리 기능 구현

### DIFF
--- a/src/main/java/com/codeisevenlycooked/evenly/EvenlyApplication.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/EvenlyApplication.java
@@ -2,8 +2,10 @@ package com.codeisevenlycooked.evenly;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class EvenlyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/UserController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/UserController.java
@@ -34,4 +34,11 @@ public class UserController {
 
         return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
     }
+
+    @DeleteMapping("/my")
+    public ResponseEntity<String> deleteMyAccount(@RequestHeader("Authorization") String token) {
+        String accessToken = token.replace("Bearer ", "");
+        userService.deleteMyAccount(accessToken);
+        return ResponseEntity.ok("회원 탈퇴가 완료되었습니다. 회원 정보가 30일 후에 완전 삭제됩니다.");
+    }
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/UserController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/UserController.java
@@ -1,0 +1,26 @@
+package com.codeisevenlycooked.evenly.controller;
+
+import com.codeisevenlycooked.evenly.config.security.JwtUtil;
+import com.codeisevenlycooked.evenly.dto.UserInfoDto;
+import com.codeisevenlycooked.evenly.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    @GetMapping("/my")
+    public ResponseEntity<UserInfoDto> getMyInfo(@RequestHeader("Authorization") String token) {
+        String accessToken = token.replace("Bearer ", "");
+        UserInfoDto userInfo = userService.getMyInfo(accessToken);
+        return ResponseEntity.ok(userInfo);
+    }
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/UserController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/UserController.java
@@ -1,14 +1,14 @@
 package com.codeisevenlycooked.evenly.controller;
 
 import com.codeisevenlycooked.evenly.config.security.JwtUtil;
+import com.codeisevenlycooked.evenly.dto.UpdatePasswordDto;
 import com.codeisevenlycooked.evenly.dto.UserInfoDto;
 import com.codeisevenlycooked.evenly.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
@@ -22,5 +22,16 @@ public class UserController {
         String accessToken = token.replace("Bearer ", "");
         UserInfoDto userInfo = userService.getMyInfo(accessToken);
         return ResponseEntity.ok(userInfo);
+    }
+
+    @PatchMapping("/my")
+    public ResponseEntity<String> updatePassword(
+            @RequestHeader("Authorization") String token,
+            @Valid @RequestBody UpdatePasswordDto updatePasswordDto) {
+
+        String accessToken = token.replace("Bearer ", "");
+        userService.updatePassword(accessToken, updatePasswordDto);
+
+        return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
     }
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/UpdatePasswordDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/UpdatePasswordDto.java
@@ -1,0 +1,21 @@
+package com.codeisevenlycooked.evenly.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdatePasswordDto {
+    @NotBlank
+    private String currentPassword;
+
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[_!@#$%^&*])[A-Za-z\\d_!@#$%^&*]{8,}$",
+            message = "비밀번호는 8자 이상이며, 대문자, 소문자, 숫자, 특수문자를 포함해야 합니다."
+    )
+    private String newPassword;
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/UserInfoDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/UserInfoDto.java
@@ -1,0 +1,18 @@
+package com.codeisevenlycooked.evenly.dto;
+
+import com.codeisevenlycooked.evenly.entity.UserRole;
+import com.codeisevenlycooked.evenly.entity.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoDto {
+    private String userId;
+    private String name;
+    private UserStatus status;
+    private UserRole role;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/User.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/User.java
@@ -55,4 +55,8 @@ public class User {
         this.status = UserStatus.DELETED;
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/User.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/User.java
@@ -51,12 +51,18 @@ public class User {
         this.createdAt = LocalDateTime.now();
     }
 
-    public void requestDelete() {
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
+
+    public void deletedAccount() {
         this.status = UserStatus.DELETED;
         this.deletedAt = LocalDateTime.now();
     }
 
-    public void updatePassword(String newPassword) {
-        this.password = newPassword;
+    public void restoreAccount() {
+        this.status = UserStatus.ACTIVE;
+        this.deletedAt = null;
     }
+
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/User.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/User.java
@@ -28,6 +28,7 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Builder.Default
+    @Setter
     private UserStatus status = UserStatus.ACTIVE;
 
     @Enumerated(EnumType.STRING)
@@ -35,12 +36,15 @@ public class User {
     @Builder.Default
     private UserRole role = UserRole.USER;
 
-    @Column(columnDefinition = "TIMESTAMP NULL")
-    private LocalDateTime deletedAt; // 탈퇴한 경우 삭제 시간 (30일 후 영구 삭제)
-
     @Column(nullable = false, updatable = false)
     @Builder.Default
     private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(columnDefinition = "TIMESTAMP NULL")
+    private LocalDateTime deletedAt; // 탈퇴한 경우 삭제 시간 (30일 후 영구 삭제)
+
+    @Column(columnDefinition = "TIMESTAMP NULL")
+    private LocalDateTime lastLoginAt;
 
     public User(String userId, String password, String name, UserRole role) {
         this.userId = userId;
@@ -49,6 +53,10 @@ public class User {
         this.status = UserStatus.ACTIVE;
         this.role = role;
         this.createdAt = LocalDateTime.now();
+    }
+
+    public void updateLastLogin() {
+        this.lastLoginAt = LocalDateTime.now();
     }
 
     public void updatePassword(String newPassword) {

--- a/src/main/java/com/codeisevenlycooked/evenly/global/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/global/scheduler/UserCleanupScheduler.java
@@ -1,0 +1,47 @@
+package com.codeisevenlycooked.evenly.global.scheduler;
+
+import com.codeisevenlycooked.evenly.entity.User;
+import com.codeisevenlycooked.evenly.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserCleanupScheduler {
+    private final UserRepository userRepository;
+
+    //서버 시작 시 삭제 실행
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void cleanUpOnStartup() {
+        log.info("서버 시작: 회원 정리 실행!");
+        deleteExpiredAccounts();
+    }
+
+    //매일 새벽 3시 실행
+    @Scheduled(cron = "0 0 3 * * ?")
+    @Transactional
+    public void deleteExpiredAccounts() {
+        LocalDateTime now = LocalDateTime.now().minusDays(30);
+
+        List<User> usersToDelete = userRepository.findAllByDeletedAtBefore(now);
+
+        if (!usersToDelete.isEmpty()) {
+            List<String> userIds = usersToDelete.stream()
+                    .map(User::getUserId)
+                    .toList();
+            log.info("삭제된 회원 ID 목록: {}", userIds);
+
+            userRepository.deleteAll(usersToDelete);
+        }
+    }
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/repository/UserRepository.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/repository/UserRepository.java
@@ -1,7 +1,9 @@
 package com.codeisevenlycooked.evenly.repository;
 
 import com.codeisevenlycooked.evenly.entity.User;
+import com.codeisevenlycooked.evenly.entity.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,4 +16,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     List<User> findAllByDeletedAtBefore(LocalDateTime now);
 
+    List<User> findByLastLoginAtBeforeAndStatus(LocalDateTime date, UserStatus status);
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/repository/UserRepository.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/repository/UserRepository.java
@@ -3,11 +3,15 @@ package com.codeisevenlycooked.evenly.repository;
 import com.codeisevenlycooked.evenly.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserId(String userId);
     // userId 중복체크
     boolean existsByUserId(String userId);
+
+    List<User> findAllByDeletedAtBefore(LocalDateTime now);
 
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/service/AuthService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/AuthService.java
@@ -42,6 +42,10 @@ public class AuthService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
+        //마지막 로그인 시간 업데이트
+        user.updateLastLogin();
+        userRepository.save(user);
+
         //Jwt 발급
         JwtUserInfoDto userInfo = new JwtUserInfoDto(user.getUserId(), user.getRole().name());
         return jwtUtil.generateToken(userInfo);

--- a/src/main/java/com/codeisevenlycooked/evenly/service/UserService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/UserService.java
@@ -1,10 +1,13 @@
 package com.codeisevenlycooked.evenly.service;
 
 import com.codeisevenlycooked.evenly.config.security.JwtUtil;
+import com.codeisevenlycooked.evenly.dto.UpdatePasswordDto;
 import com.codeisevenlycooked.evenly.dto.UserInfoDto;
 import com.codeisevenlycooked.evenly.entity.User;
 import com.codeisevenlycooked.evenly.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
 
     public UserInfoDto getMyInfo(String accessToken) {
         String userId = jwtUtil.getUserIdFromToken(accessToken);
@@ -19,4 +23,20 @@ public class UserService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         return new UserInfoDto(user.getUserId(), user.getName(), user.getStatus(), user.getRole(), user.getCreatedAt());
     }
+
+    @Transactional
+    public void updatePassword(String accessToken, UpdatePasswordDto updatePasswordDto) {
+        String userId = jwtUtil.getUserIdFromToken(accessToken);
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        //현재 비밀번호 검증
+        if (!passwordEncoder.matches(updatePasswordDto.getCurrentPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        String encodedPassword = passwordEncoder.encode(updatePasswordDto.getNewPassword());
+        user.updatePassword(encodedPassword);
+    }
+
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/service/UserService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/UserService.java
@@ -1,0 +1,22 @@
+package com.codeisevenlycooked.evenly.service;
+
+import com.codeisevenlycooked.evenly.config.security.JwtUtil;
+import com.codeisevenlycooked.evenly.dto.UserInfoDto;
+import com.codeisevenlycooked.evenly.entity.User;
+import com.codeisevenlycooked.evenly.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    public UserInfoDto getMyInfo(String accessToken) {
+        String userId = jwtUtil.getUserIdFromToken(accessToken);
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        return new UserInfoDto(user.getUserId(), user.getName(), user.getStatus(), user.getRole(), user.getCreatedAt());
+    }
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/service/UserService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/UserService.java
@@ -39,4 +39,13 @@ public class UserService {
         user.updatePassword(encodedPassword);
     }
 
+    @Transactional
+    public void deleteMyAccount(String accessToken) {
+        String userId = jwtUtil.getUserIdFromToken(accessToken);
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        user.deletedAccount();
+    }
+
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/service/UserService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/UserService.java
@@ -4,12 +4,20 @@ import com.codeisevenlycooked.evenly.config.security.JwtUtil;
 import com.codeisevenlycooked.evenly.dto.UpdatePasswordDto;
 import com.codeisevenlycooked.evenly.dto.UserInfoDto;
 import com.codeisevenlycooked.evenly.entity.User;
+import com.codeisevenlycooked.evenly.entity.UserStatus;
 import com.codeisevenlycooked.evenly.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -46,6 +54,38 @@ public class UserService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         user.deletedAccount();
+    }
+
+    /**
+     * 6개월 이상 로그인 하지 않은 계정 휴면 처리
+     */
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void processInactiveUsers() {
+        LocalDateTime inactiveThreshold = LocalDateTime.now().minusMonths(6);
+
+        List<User> inactiveUsers = userRepository.findByLastLoginAtBeforeAndStatus(inactiveThreshold, UserStatus.ACTIVE);
+        for (User user : inactiveUsers) {
+            user.setStatus(UserStatus.INACTIVE);
+        }
+
+        userRepository.saveAll(inactiveUsers);
+
+        log.info("휴면 처리된 회원 ID 목록: {}", inactiveUsers.stream().map(User::getUserId).toList());
+    }
+
+    /**
+     * 1년 동안 휴면 상태인 계정 삭제
+     */
+    @Transactional
+    @Scheduled(cron = "0 0 1 * * ?")
+    public void deleteOldInactiveUsers() {
+        LocalDateTime deleteThreshold = LocalDateTime.now().minusYears(1);
+
+        List<User> usersToDelete = userRepository.findByLastLoginAtBeforeAndStatus(deleteThreshold, UserStatus.INACTIVE);
+        userRepository.deleteAll(usersToDelete);
+
+        log.info("삭제된 휴면 회원 ID 목록: {}", usersToDelete.stream().map(User::getUserId).toList());
     }
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/my -> dev

### 변경 사항
- 아래 기능 모두 로그인 후 헤더의 Authorization의 Bearer TOKEN이 필요합니다.
    - 내 정보 조회 API 구현
    - 회원 정보 변경 - 비밀번호
    - 회원 탈퇴 API 구현
- 회원 탈퇴 30일 후 DB 삭제 스케줄러 구현 및 등록
- 휴면 계정 처리 및 삭제 로직 구현(중요한 기능 아니라.. 테스트는 진행 못했습니다)


### 테스트 결과
정보 조회
![image](https://github.com/user-attachments/assets/355abf69-fa18-4325-ba75-1ecd1710616a)
비밀번호 변경
![image](https://github.com/user-attachments/assets/668eed97-9c70-4cfc-81c0-3b0d99d56ef2)
비밀번호 일치x
![image](https://github.com/user-attachments/assets/96c610d5-09fc-4aad-b117-03a5da7b64cd)
회원 탈퇴
![image](https://github.com/user-attachments/assets/3244ac3b-54cb-4264-9bfe-76212ced6aef)
회원 탈퇴 30일 후 db 삭제
- MySQL 워크벤치에서 deleted_at을 과거 시간으로 입력(30일보다 더 이전)
![image](https://github.com/user-attachments/assets/e6cadd98-4676-4600-9f5c-9fb21d310c4a)
- 스케줄러가 잘 실행되어 로그가 남았고, 테이블에서도 삭제됨.
![image](https://github.com/user-attachments/assets/4b35a0e7-d39f-4134-993a-65dbe02890b6)