### PR TITLE
주문 생성, 조회 API 구현

### DIFF
--- a/src/main/java/com/codeisevenlycooked/evenly/config/security/JwtUtil.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/config/security/JwtUtil.java
@@ -100,9 +100,16 @@ public class JwtUtil {
     public String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
+            return bearerToken.substring(7).trim();
         }
         return null;
+    }
+
+    public String resolveToken(String token) {
+        if (token != null && token.startsWith("Bearer ")) {
+            return token.substring(7).trim();
+        }
+        return token;
     }
 
     public Date getExpiredTime(String token) {

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/OrderController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/OrderController.java
@@ -1,0 +1,30 @@
+package com.codeisevenlycooked.evenly.controller;
+
+import com.codeisevenlycooked.evenly.dto.OrderRequestDto;
+import com.codeisevenlycooked.evenly.dto.OrderResponseDto;
+import com.codeisevenlycooked.evenly.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<OrderResponseDto> createOrder(
+            @RequestHeader(value = "Authorization", required = false) String token,
+            @Valid @RequestBody OrderRequestDto requestDto) {
+
+        String userId = "test_evenie";
+
+        OrderResponseDto responseDto = orderService.createOrder(userId, requestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/OrderController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.codeisevenlycooked.evenly.controller;
 
+import com.codeisevenlycooked.evenly.config.security.JwtUtil;
 import com.codeisevenlycooked.evenly.dto.OrderRequestDto;
 import com.codeisevenlycooked.evenly.dto.OrderResponseDto;
 import com.codeisevenlycooked.evenly.service.OrderService;
@@ -17,13 +18,15 @@ import java.util.List;
 public class OrderController {
 
     private final OrderService orderService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping
     public ResponseEntity<OrderResponseDto> createOrder(
             @RequestHeader(value = "Authorization", required = false) String token,
             @Valid @RequestBody OrderRequestDto requestDto) {
 
-        String userId = "test_evenie";
+        String accessToken = jwtUtil.resolveToken(token);
+        String userId = jwtUtil.getUserIdFromToken(accessToken);
 
         OrderResponseDto responseDto = orderService.createOrder(userId, requestDto);
 
@@ -33,7 +36,9 @@ public class OrderController {
     @GetMapping
     public ResponseEntity<List<OrderResponseDto>> getOrders(
             @RequestHeader(value = "Authorization", required = false) String token) {
-        String userId = "test_evenie";
+
+        String accessToken = jwtUtil.resolveToken(token);
+        String userId = jwtUtil.getUserIdFromToken(accessToken);
 
         List<OrderResponseDto> orders = orderService.getOrders(userId);
         return ResponseEntity.ok(orders);
@@ -42,7 +47,9 @@ public class OrderController {
     @GetMapping("/{id}")
     public ResponseEntity<OrderResponseDto> getOrderById(
             @RequestHeader(value = "Authorization", required = false) String token, @PathVariable Long id) {
-        String userId = "test_evenie";
+
+        String accessToken = jwtUtil.resolveToken(token);
+        String userId = jwtUtil.getUserIdFromToken(accessToken);
 
         OrderResponseDto order = orderService.getOrderById(userId, id);
         return ResponseEntity.ok(order);

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/OrderController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/OrderController.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/orders")
 @RequiredArgsConstructor
@@ -26,5 +28,23 @@ public class OrderController {
         OrderResponseDto responseDto = orderService.createOrder(userId, requestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<OrderResponseDto>> getOrders(
+            @RequestHeader(value = "Authorization", required = false) String token) {
+        String userId = "test_evenie";
+
+        List<OrderResponseDto> orders = orderService.getOrders(userId);
+        return ResponseEntity.ok(orders);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<OrderResponseDto> getOrderById(
+            @RequestHeader(value = "Authorization", required = false) String token, @PathVariable Long id) {
+        String userId = "test_evenie";
+
+        OrderResponseDto order = orderService.getOrderById(userId, id);
+        return ResponseEntity.ok(order);
     }
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/UserController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/UserController.java
@@ -19,7 +19,8 @@ public class UserController {
 
     @GetMapping("/my")
     public ResponseEntity<UserInfoDto> getMyInfo(@RequestHeader("Authorization") String token) {
-        String accessToken = token.replace("Bearer ", "");
+        String accessToken = jwtUtil.resolveToken(token);
+
         UserInfoDto userInfo = userService.getMyInfo(accessToken);
         return ResponseEntity.ok(userInfo);
     }
@@ -29,7 +30,7 @@ public class UserController {
             @RequestHeader("Authorization") String token,
             @Valid @RequestBody UpdatePasswordDto updatePasswordDto) {
 
-        String accessToken = token.replace("Bearer ", "");
+        String accessToken = jwtUtil.resolveToken(token);
         userService.updatePassword(accessToken, updatePasswordDto);
 
         return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
@@ -37,7 +38,7 @@ public class UserController {
 
     @DeleteMapping("/my")
     public ResponseEntity<String> deleteMyAccount(@RequestHeader("Authorization") String token) {
-        String accessToken = token.replace("Bearer ", "");
+        String accessToken = jwtUtil.resolveToken(token);
         userService.deleteMyAccount(accessToken);
         return ResponseEntity.ok("회원 탈퇴가 완료되었습니다. 회원 정보가 30일 후에 완전 삭제됩니다.");
     }

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/OrderItemDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/OrderItemDto.java
@@ -1,0 +1,16 @@
+package com.codeisevenlycooked.evenly.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderItemDto {
+    private Long productId;
+
+    @Min(value = 1, message = "최소 주문 수량은 1개 이상이어야 합니다.")
+    private int quantity;
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/OrderItemResponseDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/OrderItemResponseDto.java
@@ -1,0 +1,17 @@
+package com.codeisevenlycooked.evenly.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderItemResponseDto {
+    private Long productId;
+    private String productName;
+    private int quantity;
+    private BigDecimal price;
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/OrderRequestDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/OrderRequestDto.java
@@ -1,5 +1,6 @@
 package com.codeisevenlycooked.evenly.dto;
 
+import com.codeisevenlycooked.evenly.entity.PaymentMethod;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
@@ -27,5 +28,5 @@ public class OrderRequestDto {
     private String deliveryMessage;
 
     @NotBlank(message = "결제 방법은 필수 입력값입니다.")
-    private String paymentMethod;
+    private PaymentMethod paymentMethod;
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/OrderRequestDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/OrderRequestDto.java
@@ -1,0 +1,31 @@
+package com.codeisevenlycooked.evenly.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderRequestDto {
+    @NotEmpty(message = "주문 상품 목록은 비어있을 수 없습니다.")
+    private List<OrderItemDto> orderItems;
+
+    @NotBlank(message = "수령인 이름은 필수 입력값입니다.")
+    private String receiverName;
+
+    @NotBlank(message = "주소는 필수 입력값입니다.")
+    private String address;
+
+    @NotBlank(message = "휴대폰 번호는 필수 입력값입니다.")
+    private String mobile;
+
+    private String deliveryMessage;
+
+    @NotBlank(message = "결제 방법은 필수 입력값입니다.")
+    private String paymentMethod;
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/OrderResponseDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/OrderResponseDto.java
@@ -1,0 +1,27 @@
+package com.codeisevenlycooked.evenly.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderResponseDto {
+    private Long orderId;
+    private BigDecimal totalPrice;
+    private String status;
+    private String receiverName;
+    private String address;
+    private String mobile;
+    private String deliveryMessage;
+    private String paymentMethod;
+    private LocalDateTime createdAt;
+    private List<OrderItemResponseDto> orderItems;
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/Order.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/Order.java
@@ -1,0 +1,62 @@
+package com.codeisevenlycooked.evenly.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.aspectj.weaver.ast.Or;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@NoArgsConstructor
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Setter
+    private BigDecimal totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status = OrderStatus.PENDING;
+
+    private String receiverName;
+    private String address;
+    private String mobile;
+    @Column(length = 5000)
+    private String deliveryMessage;
+    private String paymentMethod;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    public Order(User user, BigDecimal totalPrice, String receiverName, String address, String mobile, String deliveryMessage, String paymentMethod) {
+        this.user = user;
+        this.totalPrice = totalPrice;
+        this.receiverName = receiverName;
+        this.address = address;
+        this.mobile = mobile;
+        this.deliveryMessage = deliveryMessage;
+        this.paymentMethod = paymentMethod;
+    }
+
+    public void addOrderItem(OrderItem item) {
+        orderItems.add(item);
+        item.setOrder(this);
+    }
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/OrderItem.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/OrderItem.java
@@ -1,0 +1,37 @@
+package com.codeisevenlycooked.evenly.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "order_items")
+@Getter
+@NoArgsConstructor
+public class OrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    @Setter
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    private int quantity;
+    private BigDecimal price;
+
+    public OrderItem(Product product, int quantity, BigDecimal price) {
+        this.product = product;
+        this.quantity = quantity;
+        this.price = price;
+    }
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/OrderStatus.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.codeisevenlycooked.evenly.entity;
+
+public enum OrderStatus {
+    PENDING,
+    SHIPPED,
+    DELIVERED,
+    GOOD
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/PaymentMethod.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/PaymentMethod.java
@@ -1,0 +1,8 @@
+package com.codeisevenlycooked.evenly.entity;
+
+public enum PaymentMethod {
+    CARD,
+    BANKTRANSFER,
+    KAKAO,
+    TOSS
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/repository/OrderItemRepository.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/repository/OrderItemRepository.java
@@ -1,0 +1,7 @@
+package com.codeisevenlycooked.evenly.repository;
+
+import com.codeisevenlycooked.evenly.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/repository/OrderRepository.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/repository/OrderRepository.java
@@ -1,10 +1,15 @@
 package com.codeisevenlycooked.evenly.repository;
 
 import com.codeisevenlycooked.evenly.entity.Order;
+import com.codeisevenlycooked.evenly.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByUserId(long userId);
+
+    List<Order> findByUser(User user);
+    Optional<Order> findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/repository/OrderRepository.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/repository/OrderRepository.java
@@ -1,0 +1,10 @@
+package com.codeisevenlycooked.evenly.repository;
+
+import com.codeisevenlycooked.evenly.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    List<Order> findByUserId(long userId);
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
@@ -1,0 +1,82 @@
+package com.codeisevenlycooked.evenly.service;
+
+import com.codeisevenlycooked.evenly.dto.OrderItemDto;
+import com.codeisevenlycooked.evenly.dto.OrderItemResponseDto;
+import com.codeisevenlycooked.evenly.dto.OrderRequestDto;
+import com.codeisevenlycooked.evenly.dto.OrderResponseDto;
+import com.codeisevenlycooked.evenly.entity.Order;
+import com.codeisevenlycooked.evenly.entity.OrderItem;
+import com.codeisevenlycooked.evenly.entity.Product;
+import com.codeisevenlycooked.evenly.entity.User;
+import com.codeisevenlycooked.evenly.repository.OrderItemRepository;
+import com.codeisevenlycooked.evenly.repository.OrderRepository;
+import com.codeisevenlycooked.evenly.repository.ProductRepository;
+import com.codeisevenlycooked.evenly.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public OrderResponseDto createOrder(String userId, OrderRequestDto requestDto) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        Order order = new Order(
+                user,
+                BigDecimal.ZERO,
+                requestDto.getReceiverName(),
+                requestDto.getAddress(),
+                requestDto.getMobile(),
+                requestDto.getDeliveryMessage(),
+                requestDto.getPaymentMethod()
+        );
+
+        BigDecimal totalPrice = BigDecimal.ZERO;
+        List<OrderItemResponseDto> orderItemResponses = new ArrayList<>();
+
+        for (OrderItemDto itemDto : requestDto.getOrderItems()) {
+            Product product = productRepository.findById(itemDto.getProductId())
+                    .orElseThrow(() -> new IllegalArgumentException("상품이 없습니다."));
+
+            BigDecimal itemTotalPrice = BigDecimal.valueOf(product.getPrice())
+                    .multiply(BigDecimal.valueOf(itemDto.getQuantity()));
+            totalPrice = totalPrice.add(itemTotalPrice);
+
+            order.addOrderItem(new OrderItem(product, itemDto.getQuantity(), BigDecimal.valueOf(product.getPrice())));
+            orderItemResponses.add(new OrderItemResponseDto(
+                    product.getId(),
+                    product.getName(),
+                    itemDto.getQuantity(),
+                    BigDecimal.valueOf(product.getPrice()))
+            );
+        }
+
+        order.setTotalPrice(totalPrice);
+        orderRepository.save(order);
+
+        return OrderResponseDto.builder()
+                .orderId(order.getId())
+                .totalPrice(order.getTotalPrice())
+                .status(order.getStatus().name())
+                .receiverName(order.getReceiverName())
+                .address(order.getAddress())
+                .mobile(order.getMobile())
+                .deliveryMessage(order.getDeliveryMessage())
+                .paymentMethod(order.getPaymentMethod())
+                .createdAt(order.getCreatedAt())
+                .orderItems(orderItemResponses)
+                .build();
+    }
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
@@ -50,6 +50,10 @@ public class OrderService {
             Product product = productRepository.findById(itemDto.getProductId())
                     .orElseThrow(() -> new IllegalArgumentException("상품이 없습니다."));
 
+            if (itemDto.getQuantity() > product.getStock()) {
+                throw new IllegalArgumentException("상품 `" + product.getName() + "`의 재고가 부족합니다.");
+            }
+
             BigDecimal itemTotalPrice = BigDecimal.valueOf(product.getPrice())
                     .multiply(BigDecimal.valueOf(itemDto.getQuantity()));
             totalPrice = totalPrice.add(itemTotalPrice);

--- a/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
@@ -35,7 +35,7 @@ public class OrderService {
                 requestDto.getAddress(),
                 requestDto.getMobile(),
                 requestDto.getDeliveryMessage(),
-                requestDto.getPaymentMethod()
+                requestDto.getPaymentMethod().name()
         );
 
         BigDecimal totalPrice = BigDecimal.ZERO;

--- a/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
@@ -79,4 +79,49 @@ public class OrderService {
                 .orderItems(orderItemResponses)
                 .build();
     }
+
+    @Transactional
+    public List<OrderResponseDto> getOrders(String userId) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        List<Order> orders = orderRepository.findByUser(user);
+        return orders.stream().map(this::converToResponseDto).toList();
+    }
+
+    @Transactional
+    public OrderResponseDto getOrderById(String userId, Long orderId) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Order order = orderRepository.findByIdAndUser(orderId, user)
+                .orElseThrow(() -> new IllegalArgumentException("해당 주문을 찾을 수 없습니다."));
+
+        return converToResponseDto(order);
+    }
+
+    private OrderResponseDto converToResponseDto(Order order) {
+        List<OrderItemResponseDto> orderItems = order.getOrderItems().stream()
+                .map(item -> new OrderItemResponseDto(
+                        item.getProduct().getId(),
+                        item.getProduct().getName(),
+                        item.getQuantity(),
+                        item.getPrice()))
+                .toList();
+
+        return OrderResponseDto.builder()
+                .orderId(order.getId())
+                .totalPrice(order.getTotalPrice())
+                .status(order.getStatus().name())
+                .receiverName(order.getReceiverName())
+                .address(order.getAddress())
+                .mobile(order.getMobile())
+                .deliveryMessage(order.getDeliveryMessage())
+                .paymentMethod(order.getPaymentMethod())
+                .createdAt(order.getCreatedAt())
+                .orderItems(orderItems)
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
@@ -4,10 +4,7 @@ import com.codeisevenlycooked.evenly.dto.OrderItemDto;
 import com.codeisevenlycooked.evenly.dto.OrderItemResponseDto;
 import com.codeisevenlycooked.evenly.dto.OrderRequestDto;
 import com.codeisevenlycooked.evenly.dto.OrderResponseDto;
-import com.codeisevenlycooked.evenly.entity.Order;
-import com.codeisevenlycooked.evenly.entity.OrderItem;
-import com.codeisevenlycooked.evenly.entity.Product;
-import com.codeisevenlycooked.evenly.entity.User;
+import com.codeisevenlycooked.evenly.entity.*;
 import com.codeisevenlycooked.evenly.repository.OrderRepository;
 import com.codeisevenlycooked.evenly.repository.ProductRepository;
 import com.codeisevenlycooked.evenly.repository.UserRepository;
@@ -48,7 +45,8 @@ public class OrderService {
             Product product = productRepository.findById(itemDto.getProductId())
                     .orElseThrow(() -> new IllegalArgumentException("상품이 없습니다."));
 
-            if (itemDto.getQuantity() > product.getStock()) {
+            if (product.getStock() <= 0 || product.getStatus() == ProductStatus.SOLD_OUT ||
+                    itemDto.getQuantity() > product.getStock()) {
                 throw new IllegalArgumentException("상품 `" + product.getName() + "`의 재고가 부족합니다.");
             }
 

--- a/src/test/java/com/codeisevenlycooked/evenly/service/OrderServiceTest.java
+++ b/src/test/java/com/codeisevenlycooked/evenly/service/OrderServiceTest.java
@@ -1,0 +1,91 @@
+package com.codeisevenlycooked.evenly.service;
+
+import com.codeisevenlycooked.evenly.dto.OrderItemDto;
+import com.codeisevenlycooked.evenly.dto.OrderRequestDto;
+import com.codeisevenlycooked.evenly.dto.OrderResponseDto;
+import com.codeisevenlycooked.evenly.entity.*;
+import com.codeisevenlycooked.evenly.repository.OrderRepository;
+import com.codeisevenlycooked.evenly.repository.ProductRepository;
+import com.codeisevenlycooked.evenly.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static com.codeisevenlycooked.evenly.entity.UserRole.USER;
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock private OrderRepository orderRepository;
+    @Mock private ProductRepository productRepository;
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks private OrderService orderService;
+
+    private OrderRequestDto requestDto;
+    private User user;
+    private Product product;
+    private Order order;
+
+    @BeforeEach
+    void setUp() {
+        user = new User("testUserId", "password123", "이브니", UserRole.USER); // 실제 값 사용
+        product = new Product();
+        ReflectionTestUtils.setField(product, "id", 1L);
+        ReflectionTestUtils.setField(product, "price", 25000);
+
+        ReflectionTestUtils.setField(product, "name", "상품명");
+        ReflectionTestUtils.setField(product, "description", "상품 설명");
+        ReflectionTestUtils.setField(product, "imageUrl", "URL");
+        ReflectionTestUtils.setField(product, "category", "카테고리");
+        ReflectionTestUtils.setField(product, "stock", 10);
+        ReflectionTestUtils.setField(product, "status", ProductStatus.AVAILABLE);
+
+        requestDto = new OrderRequestDto(
+                List.of(new OrderItemDto(1L, 2)), // 상품 ID = 1, 수량 = 2
+                "이브니",
+                "서울시 강남구",
+                "010-2222-4444",
+                "문 앞에 놓아주세요",
+                "CARD"
+        );
+
+        order = new Order(user, BigDecimal.ZERO,
+                requestDto.getReceiverName(), requestDto.getAddress(), requestDto.getMobile(),
+                requestDto.getDeliveryMessage(), requestDto.getPaymentMethod());
+    }
+
+    @Test
+    void createOrder_success() {
+        when(userRepository.findByUserId(anyString())).thenReturn(Optional.of(user));
+        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        OrderResponseDto responseDto = orderService.createOrder("testUserId", requestDto);
+
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto.getReceiverName()).isEqualTo(requestDto.getReceiverName());
+        assertThat(responseDto.getOrderItems()).hasSize(1);
+        assertThat(responseDto.getTotalPrice()).isEqualTo(BigDecimal.valueOf(50000));
+
+        verify(userRepository, times(1)).findByUserId(anyString());
+        verify(productRepository, times(1)).findById(1L);
+        verify(orderRepository, times(1)).save(any(Order.class));
+    }
+
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feat/order -> dev

### 변경 사항
- 주문 생성 API 구현
- stock 관련 예외 적용
- 주문 목록, 상세 조회 API 구현
- 로그인 인증 적용 (주문 관련 API 이용시 로그인 후 생성된 Bearer token 필수)

### 테스트 결과
- 주문 생성
![image](https://github.com/user-attachments/assets/004ff423-60ca-4094-8d17-212b69364bb0)
- 주문 생성시 재고 부족
![image](https://github.com/user-attachments/assets/ea66499a-bc9d-4768-89f5-8f66bd475dee)
- 주문 목록 조회
![image](https://github.com/user-attachments/assets/371fec39-3564-4845-ba56-7826c1ceef7d)
- 주문 상세 조회
![image](https://github.com/user-attachments/assets/012c185e-7c81-4f51-b47f-167f8bac99c2)

