### PR TITLE
상품 페이지네이션 및 카테고리 쿼리 추가

### DIFF
--- a/src/main/java/com/codeisevenlycooked/evenly/config/CategoryInitializer.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/config/CategoryInitializer.java
@@ -1,0 +1,34 @@
+package com.codeisevenlycooked.evenly.config;
+
+import com.codeisevenlycooked.evenly.entity.Category;
+import com.codeisevenlycooked.evenly.repository.CategoryRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryInitializer implements ApplicationRunner {
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        List<Category> defaultCategories = List.of(
+                new Category(1L, "NEW"),
+                new Category(2L, "LIGHTING"),
+                new Category(3L, "OFFICE"),
+                new Category(4L, "KITCHEN"),
+                new Category(5L, "HOME_DECOR")
+        );
+
+        for (Category category : defaultCategories) {
+            if (!categoryRepository.existsById(category.getId())) {
+                categoryRepository.save(category);
+            }
+        }
+    }
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/AdminProductController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/AdminProductController.java
@@ -2,6 +2,7 @@ package com.codeisevenlycooked.evenly.controller;
 
 import com.codeisevenlycooked.evenly.dto.AdminProductDto;
 import com.codeisevenlycooked.evenly.entity.Product;
+import com.codeisevenlycooked.evenly.repository.CategoryRepository;
 import com.codeisevenlycooked.evenly.service.ProductService;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Controller;
@@ -15,9 +16,11 @@ import org.springframework.web.bind.annotation.*;
 public class AdminProductController {
 
     private final ProductService productService;
+    private final CategoryRepository categoryRepository;
 
-    public AdminProductController(ProductService productService) {
+    public AdminProductController(ProductService productService, CategoryRepository categoryRepository) {
         this.productService = productService;
+        this.categoryRepository = categoryRepository;
     }
 
     // 목록 조회(status DELETED도 조회 가능)
@@ -31,6 +34,7 @@ public class AdminProductController {
     // 상품 등록 폼
     @GetMapping("/new")
     public String showCreateForm(Model model) {
+        model.addAttribute("categoryList", categoryRepository.findAll());
         model.addAttribute("product", new AdminProductDto());
         return "admin/product-form";
     }
@@ -50,6 +54,7 @@ public class AdminProductController {
     public String showEditForm(@PathVariable Long id, Model model) {
         Product product = productService.getProductByIdForAdmin(id);
         AdminProductDto productDto = productService.convertToDto(product);
+        model.addAttribute("categoryList", categoryRepository.findAll());
         model.addAttribute("product", productDto);
         return "admin/product-form";
     }

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/AdminProductController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/AdminProductController.java
@@ -1,15 +1,19 @@
 package com.codeisevenlycooked.evenly.controller;
 
 import com.codeisevenlycooked.evenly.dto.AdminProductDto;
+import com.codeisevenlycooked.evenly.entity.Category;
 import com.codeisevenlycooked.evenly.entity.Product;
 import com.codeisevenlycooked.evenly.repository.CategoryRepository;
 import com.codeisevenlycooked.evenly.service.ProductService;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Controller
 @RequestMapping("/admin/products")
@@ -27,7 +31,6 @@ public class AdminProductController {
     @GetMapping
     public String list(Model model) {
         model.addAttribute("products", productService.getAllProductsForAdmin());
-        System.out.println(productService.getAllProductsForAdmin());
         return "admin/products";
     }
 
@@ -41,10 +44,13 @@ public class AdminProductController {
 
     // 상품 등록 처리
     @PostMapping("/new")
-    public String create(@ModelAttribute @Validated AdminProductDto productDto, BindingResult result) {
+    public String create(@ModelAttribute("product") @Validated AdminProductDto productDto,
+                         BindingResult result) {
+        System.out.println("categoryId: " + productDto.getCategoryId());
         if (result.hasErrors()) {
             return "admin/product-form";
         }
+
         productService.saveProduct(productDto);
         return "redirect:/admin/products";
     }
@@ -65,6 +71,7 @@ public class AdminProductController {
         if (result.hasErrors()) {
             return "admin/product-form";
         }
+
         productService.updateProduct(id, productDto);
         return "redirect:/admin/products";
     }

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/ProductController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/ProductController.java
@@ -1,16 +1,16 @@
 package com.codeisevenlycooked.evenly.controller;
 
+import com.codeisevenlycooked.evenly.dto.PagedProductResponse;
 import com.codeisevenlycooked.evenly.dto.ProductResponseDto;
 import com.codeisevenlycooked.evenly.entity.Product;
 import com.codeisevenlycooked.evenly.repository.ProductRepository;
 import com.codeisevenlycooked.evenly.service.ProductService;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,8 +22,20 @@ public class ProductController {
 
     //상품 목록 조회
     @GetMapping
-    public ResponseEntity<List<ProductResponseDto>> getAllProducts() {
-        return ResponseEntity.ok(productService.getAllProducts());
+    public ResponseEntity<PagedProductResponse> getProducts(
+            @RequestParam(value = "category", required = false) Long categoryId,
+            @RequestParam(value = "page", defaultValue = "1") int page
+    ) {
+        Page<ProductResponseDto> productPage = productService.getProductsByCategory(categoryId, page);
+        PagedProductResponse response = new PagedProductResponse(
+                productPage.getContent(),
+                productPage.getNumber() + 1,
+                productPage.getTotalPages(),
+                productPage.getTotalElements(),
+                productPage.isFirst(),
+                productPage.isLast()
+        );
+        return ResponseEntity.ok(response);
     }
 
     //상품 상세 조회 ( = 단일 상품 조회 )
@@ -32,3 +44,5 @@ public class ProductController {
         return ResponseEntity.ok(productService.getProductById(id));
     }
 }
+
+

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/AdminProductDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/AdminProductDto.java
@@ -1,6 +1,7 @@
 package com.codeisevenlycooked.evenly.dto;
 
 
+import com.codeisevenlycooked.evenly.entity.Category;
 import com.codeisevenlycooked.evenly.entity.ProductStatus;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -26,11 +27,14 @@ public class AdminProductDto {
     private String imageUrl;
 
     @NotBlank(message = "카테고리를 입력해주세요.")
-    private String category;
+    private Category category;
 
     @Min(value = 0, message = "재고는 0 이상이어야 합니다.")
     private int stock;
 
     private String status; // "AVAILABLE", "SOLD_OUT", "DELETED"
 
+    public Long getCategoryId() {
+        return category.getId();
+    }
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/AdminProductDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/AdminProductDto.java
@@ -5,9 +5,10 @@ import com.codeisevenlycooked.evenly.entity.Category;
 import com.codeisevenlycooked.evenly.entity.ProductStatus;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
-@Getter@Setter
+@Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -20,13 +21,13 @@ public class AdminProductDto {
     @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
     private int price;
 
-    @NotBlank(message = "상품 설명을 입력해주세요.")
     private String description;
 
     @NotBlank(message = "이미지 URL을 입력해주세요.")
     private String imageUrl;
 
-    @NotBlank(message = "카테고리를 입력해주세요.")
+    private Long categoryId;
+
     private Category category;
 
     @Min(value = 0, message = "재고는 0 이상이어야 합니다.")
@@ -34,7 +35,4 @@ public class AdminProductDto {
 
     private String status; // "AVAILABLE", "SOLD_OUT", "DELETED"
 
-    public Long getCategoryId() {
-        return category.getId();
-    }
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/PagedProductResponse.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/PagedProductResponse.java
@@ -1,0 +1,17 @@
+package com.codeisevenlycooked.evenly.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PagedProductResponse {
+    private List<ProductResponseDto> content;
+    private int pageNumber;
+    private int totalPages;
+    private long totalElements;
+    private boolean first;
+    private boolean last;
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/ProductResponseDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/ProductResponseDto.java
@@ -1,5 +1,6 @@
 package com.codeisevenlycooked.evenly.dto;
 
+import com.codeisevenlycooked.evenly.entity.Category;
 import com.codeisevenlycooked.evenly.entity.Product;
 import com.codeisevenlycooked.evenly.entity.ProductStatus;
 import lombok.Getter;
@@ -10,7 +11,7 @@ public class ProductResponseDto {
     private final String name;
     private final int price;
     private final String imageUrl;
-    private final String category;
+    private final Category category;
     private final ProductStatus status;
 
     public ProductResponseDto(Product product) {

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/Category.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/Category.java
@@ -1,0 +1,23 @@
+package com.codeisevenlycooked.evenly.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "category")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+    @Id
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/Product.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/Product.java
@@ -31,8 +31,9 @@ public class Product {
     @Column(nullable = false)
     private String imageUrl;
 
-    @Column(nullable = false)
-    private String category;
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
 
     @Column(nullable = false)
     private int stock;

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/Product.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/Product.java
@@ -31,7 +31,7 @@ public class Product {
     @Column(nullable = false)
     private String imageUrl;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 

--- a/src/main/java/com/codeisevenlycooked/evenly/repository/CategoryRepository.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.codeisevenlycooked.evenly.repository;
+
+import com.codeisevenlycooked.evenly.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/repository/ProductRepository.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/repository/ProductRepository.java
@@ -2,11 +2,18 @@ package com.codeisevenlycooked.evenly.repository;
 
 import com.codeisevenlycooked.evenly.entity.Product;
 import com.codeisevenlycooked.evenly.entity.ProductStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Collection;
 import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findByStatusNot(ProductStatus status);
+
+    // 페이지네이션
+    Page<Product> findByStatusNot(ProductStatus status, Pageable pageable);
+
+    Page<Product> findByCategoryIdAndStatusNot(Long categoryId, ProductStatus status, Pageable pageable);
+
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/service/ProductService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/ProductService.java
@@ -79,7 +79,7 @@ public class ProductService {
                 .stock(productDto.getStock())
                 .status(ProductStatus.valueOf(productDto.getStatus())) // ENUM 변환
                 .build();
-        
+
         productRepository.save(product);
     }
 

--- a/src/main/java/com/codeisevenlycooked/evenly/service/ProductService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/ProductService.java
@@ -63,9 +63,13 @@ public class ProductService {
     }
 
     // 등록
+    @Transactional
     public void saveProduct(AdminProductDto productDto) {
-        Category category = categoryRepository.findById(productDto.getCategory().getId())
-                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+        Long categoryId = productDto.getCategoryId();
+
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new RuntimeException("카테고리를 찾을 수 없습니다."));
+
         Product product = Product.builder()
                 .name(productDto.getName())
                 .price(productDto.getPrice())
@@ -75,6 +79,7 @@ public class ProductService {
                 .stock(productDto.getStock())
                 .status(ProductStatus.valueOf(productDto.getStatus())) // ENUM 변환
                 .build();
+        
         productRepository.save(product);
     }
 
@@ -85,8 +90,8 @@ public class ProductService {
     public void updateProduct(Long id, AdminProductDto productDto) {
         Product existingProduct = getProductByIdForAdmin(id);
 
-        Category category = categoryRepository.findById(productDto.getCategory().getId())
-                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+        Category category = categoryRepository.findById(productDto.getCategoryId())
+                .orElseThrow(() -> new RuntimeException("카테고리를 찾을 수 없습니다."));
 
         ProductStatus status = ProductStatus.valueOf(productDto.getStatus());
         if (productDto.getStock() == 0) {
@@ -115,7 +120,7 @@ public class ProductService {
                 .price(product.getPrice())
                 .description(product.getDescription())
                 .imageUrl(product.getImageUrl())
-                .category(product.getCategory())
+                .categoryId(product.getCategory().getId())
                 .stock(product.getStock())
                 .status(product.getStatus().name())
                 .build();

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,4 @@
+-- 상품 초기 데이터 --
 INSERT INTO products (name, price, description, image_url, category, stock, status, created_at)
 SELECT 'Barro Plate-Set of 2-Ø18-Dark blue',
        35000,
@@ -26,3 +27,4 @@ SELECT 'Apollo Portable Lamp-White opal glass',
 WHERE NOT EXISTS (
     SELECT 1 FROM products WHERE name = 'Apollo Portable Lamp-White opal glass'
 );
+

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,11 +1,11 @@
 -- 상품 초기 데이터 --
-INSERT INTO products (name, price, description, image_url, category, stock, status, created_at)
+INSERT INTO products (name, price, description, image_url, category_id, stock, status, created_at)
 SELECT 'Barro Plate-Set of 2-Ø18-Dark blue',
        35000,
        CONCAT('Designed by Portuguese Rui Pereira, the Barro Plate is part of a tableware collection that brings the warmth and beautiful simplicity of terracotta to the table. Meaning ‘red clay’ in Portuguese, Barro represents the designer’s appreciation of the traditions and uses associated with this ancient material. Barro Plate’s rolled-edge detail combined with its soft touch and proportions create a sense of stability that makes the plate pleasurable to use. Crafted in Portugal from durable terracotta, the Barro Plate is glazed in a variety of high gloss colours that can be matched or mixed in innumerable personalised combinations. The plates come in a set of two.' , CHAR(10), 'Color: Dark blue
  ', CHAR(10),'Size: D18') ,
        'https://www.hay.com/img_20230907111544/globalassets/inriver/integration/service/ac459-a668-ai60-02au_barro-plate-oe18-set-of-2-dark-blue_gb_1220x1220_brandvariant.jpg?w=600',
-       'Kitchen',
+       4,
        0,
        'SOLD_OUT',
        CONVERT_TZ(NOW(), 'UTC', 'Asia/Seoul')
@@ -13,14 +13,14 @@ WHERE NOT EXISTS (
     SELECT 1 FROM products WHERE name = 'Barro Plate-Set of 2-Ø18-Dark blue'
 );
 
-INSERT INTO products (name, price, description, image_url, category, stock, status, created_at)
+INSERT INTO products (name, price, description, image_url, category_id, stock, status, created_at)
 SELECT 'Apollo Portable Lamp-White opal glass',
        150000,
        CONCAT('Designed by STUDIO 0405, the Apollo Portable Lamp is a portable and free-standing lamp for indoor and outdoor use that creates space and intimacy wherever it is placed. Hand-made in a single piece of opal glass, its rounded curves and unified silhouette are a contemporary interpretation of the classic lamp form. The light source and rechargeable battery are concealed within the shade, illuminating the upper part to provide a warm, ambient glow. Apollo''s portability and deliberate simplicity of design make it suitable for using in many rooms in a domestic environment, as well as cafés, patios and other outdoor spaces.', CHAR(10), 'Size:', CHAR(10), 'H21.8 x W12.5 x L12.5', CHAR(10), 'Color: White', CHAR(10), 'Material: Glass', CHAR(10),
               'Cord: 100 cm', CHAR(10), 'Bulb: LED G4', CHAR(10), 'Dimmable: Yes', CHAR(10),
               'Switch: Touch step dimmer', CHAR(10), 'IP: 44', CHAR(10), 'Supply: 5V, 2A'),
        'https://www.hay.com/img_20240404083132/globalassets/inriver/integration/service/ae378-b508_apollo-portable-white_gb_1220x1220_brandvariant.jpg?w=600',
-       'Lighting',
+       2,
        10,
        'AVAILABLE',
        CONVERT_TZ(NOW(), 'UTC', 'Asia/Seoul')

--- a/src/main/resources/templates/admin/product-form.html
+++ b/src/main/resources/templates/admin/product-form.html
@@ -43,7 +43,12 @@
 
             <div class="mb-3">
                 <label class="form-label">카테고리</label>
-                <input type="text" class="form-control" th:field="*{category}" required>
+                <select class="form-control" th:field="*{category}">
+                    <option th:each="category : ${categoryList}"
+                            th:value="${category.id}"
+                            th:text="|${category.id} : ${category.name}|">
+                    </option>
+                </select>
             </div>
 
             <div class="mb-3">

--- a/src/main/resources/templates/admin/product-form.html
+++ b/src/main/resources/templates/admin/product-form.html
@@ -33,7 +33,7 @@
 
             <div class="mb-3">
                 <label class="form-label">상품 설명</label>
-                <textarea class="form-control" th:field="*{description}" rows="3" required></textarea>
+                <textarea class="form-control" th:field="*{description}" rows="3"></textarea>
             </div>
 
             <div class="mb-3">
@@ -43,10 +43,10 @@
 
             <div class="mb-3">
                 <label class="form-label">카테고리</label>
-                <select class="form-control" th:field="*{category}">
+                <select class="form-control" th:field="*{categoryId}" required>
                     <option th:each="category : ${categoryList}"
                             th:value="${category.id}"
-                            th:text="|${category.id} : ${category.name}|">
+                            th:text="${category.id} + ' : ' + ${category.name}">
                     </option>
                 </select>
             </div>

--- a/src/main/resources/templates/admin/product-form.html
+++ b/src/main/resources/templates/admin/product-form.html
@@ -46,7 +46,8 @@
                 <select class="form-control" th:field="*{categoryId}" required>
                     <option th:each="category : ${categoryList}"
                             th:value="${category.id}"
-                            th:text="${category.id} + ' : ' + ${category.name}">
+                            th:text="${category.id} + ' : ' + ${category.name}"
+                            th:disabled="${category.id == 1}">
                     </option>
                 </select>
             </div>
@@ -78,4 +79,12 @@
     </div>
 </section>
 </body>
+
+<script>
+    const categorySelect = document.getElementById('category');
+    const option = categorySelect.querySelector('option[value="1"]');
+    if (option) {
+        option.disabled = true;
+    }
+</script>
 </html>

--- a/src/main/resources/templates/admin/products.html
+++ b/src/main/resources/templates/admin/products.html
@@ -17,6 +17,7 @@
             <thead>
             <tr>
                 <th>ID</th>
+                <th>카테고리</th>
                 <th>상품명</th>
                 <th>가격</th>
                 <th>재고</th>
@@ -27,6 +28,7 @@
             <tbody>
             <tr th:each="product : ${products}">
                 <td th:text="${product.id}"></td>
+                <td th:text="${product.category.name}"></td>
                 <td th:text="${product.name}"></td>
                 <td th:text="${product.price}"></td>
                 <td th:text="${product.stock}"></td>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/product/category&pagination -> dev

### 변경 사항
- 상품 목록 조회시 `/products?category=1&page=1` 쿼리로 카테고리와 페이지네이션이 가능하도록 했습니다.
- 관리자 페이지에서 목록 조회시 카테고리 표시, 상품 수정 및 등록 시 카테고리 선택 가능(기존 text)하도록 했습니다. 

⭐ products 데이터에 category 컬럼이 category_id 컬럼으로 변경되었습니다. 혹시 관련 에러가 난다면 디코 부탁드립니다.


### 테스트 결과
![image](https://github.com/user-attachments/assets/1a41d4a9-0004-409e-92ee-2dded2a79251)

![image](https://github.com/user-attachments/assets/b41b3197-7379-44bb-ae19-8283317de740)

![image](https://github.com/user-attachments/assets/86149dfd-1f55-465a-8281-e971aa65701c)


