### PR TITLE
결제 API 구현

### DIFF
--- a/src/main/java/com/codeisevenlycooked/evenly/controller/OrderController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/OrderController.java
@@ -44,14 +44,14 @@ public class OrderController {
         return ResponseEntity.ok(orders);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<OrderResponseDto> getOrderById(
-            @RequestHeader(value = "Authorization", required = false) String token, @PathVariable Long id) {
+    @GetMapping("/{orderNumber}")
+    public ResponseEntity<OrderResponseDto> getOrderByOrderNumber(
+            @RequestHeader(value = "Authorization", required = false) String token, @PathVariable String orderNumber) {
 
         String accessToken = jwtUtil.resolveToken(token);
         String userId = jwtUtil.getUserIdFromToken(accessToken);
 
-        OrderResponseDto order = orderService.getOrderById(userId, id);
+        OrderResponseDto order = orderService.getOrderByOrderNumber(userId, orderNumber);
         return ResponseEntity.ok(order);
     }
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/PaymentController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/PaymentController.java
@@ -1,8 +1,6 @@
 package com.codeisevenlycooked.evenly.controller;
 
 import com.codeisevenlycooked.evenly.dto.PaymentRequestDto;
-import com.codeisevenlycooked.evenly.dto.PaymentSuccessDto;
-import com.codeisevenlycooked.evenly.entity.Payment;
 import com.codeisevenlycooked.evenly.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/codeisevenlycooked/evenly/controller/PaymentController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/PaymentController.java
@@ -1,0 +1,30 @@
+package com.codeisevenlycooked.evenly.controller;
+
+import com.codeisevenlycooked.evenly.dto.PaymentRequestDto;
+import com.codeisevenlycooked.evenly.dto.PaymentSuccessDto;
+import com.codeisevenlycooked.evenly.entity.Payment;
+import com.codeisevenlycooked.evenly.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/payments")
+    public ResponseEntity<String> processPayment(@RequestBody PaymentRequestDto paymentRequestDto) {
+
+        boolean isPaymentSuccess = paymentService.processPayment(paymentRequestDto.getOrderId());
+
+        if (isPaymentSuccess) {
+            return ResponseEntity.ok("결제 성공");
+        } else {
+            return ResponseEntity.status(400).body("결제 실패");
+        }
+    }
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/OrderRequestDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/OrderRequestDto.java
@@ -3,6 +3,7 @@ package com.codeisevenlycooked.evenly.dto;
 import com.codeisevenlycooked.evenly.entity.PaymentMethod;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,6 +28,6 @@ public class OrderRequestDto {
 
     private String deliveryMessage;
 
-    @NotBlank(message = "결제 방법은 필수 입력값입니다.")
+    @NotNull(message = "결제 방법은 필수 입력값입니다.")
     private PaymentMethod paymentMethod;
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/OrderResponseDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/OrderResponseDto.java
@@ -15,6 +15,7 @@ import java.util.List;
 @Builder
 public class OrderResponseDto {
     private Long orderId;
+    private String orderNumber;
     private BigDecimal totalPrice;
     private String status;
     private String receiverName;

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/PaymentRequestDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/PaymentRequestDto.java
@@ -1,0 +1,17 @@
+package com.codeisevenlycooked.evenly.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentRequestDto {
+    private Long orderId;
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/Order.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/Order.java
@@ -22,6 +22,9 @@ public class Order {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, unique = true)
+    private String orderNumber;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -50,7 +53,8 @@ public class Order {
     private List<Payment> payments;
 
 
-    public Order(User user, BigDecimal totalPrice, String receiverName, String address, String mobile, String deliveryMessage, String paymentMethod) {
+    public Order(String orderNumber, User user, BigDecimal totalPrice, String receiverName, String address, String mobile, String deliveryMessage, String paymentMethod) {
+        this.orderNumber = orderNumber;
         this.user = user;
         this.totalPrice = totalPrice;
         this.receiverName = receiverName;

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/Order.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/Order.java
@@ -45,6 +45,10 @@ public class Order {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
 
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    private List<Payment> payments;
+
+
     public Order(User user, BigDecimal totalPrice, String receiverName, String address, String mobile, String deliveryMessage, String paymentMethod) {
         this.user = user;
         this.totalPrice = totalPrice;
@@ -58,5 +62,9 @@ public class Order {
     public void addOrderItem(OrderItem item) {
         orderItems.add(item);
         item.setOrder(this);
+    }
+
+    public void changeStatus (OrderStatus newStatus) {
+        this.status = newStatus;
     }
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/Order.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/Order.java
@@ -30,7 +30,8 @@ public class Order {
     private BigDecimal totalPrice;
 
     @Enumerated(EnumType.STRING)
-    private OrderStatus status = OrderStatus.PENDING;
+    @Column(length = 20)
+    private OrderStatus status = OrderStatus.PAYMENT_PENDING;
 
     private String receiverName;
     private String address;

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/OrderStatus.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/OrderStatus.java
@@ -1,6 +1,7 @@
 package com.codeisevenlycooked.evenly.entity;
 
 public enum OrderStatus {
+    PAYMENT_PENDING,
     PENDING,
     SHIPPED,
     DELIVERED,

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/Payment.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/Payment.java
@@ -1,0 +1,37 @@
+package com.codeisevenlycooked.evenly.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Payment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private BigDecimal amount;
+    private String paymentMethod;
+    private String status;
+    private LocalDateTime transactionTime;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+
+    public Payment(BigDecimal amount, String paymentMethod, String status, LocalDateTime transactionTime, Order order) {
+        this.amount = amount;
+        this.paymentMethod = paymentMethod;
+        this.status = status;
+        this.transactionTime = transactionTime;
+        this.order = order;
+    }
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/Product.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/Product.java
@@ -49,4 +49,10 @@ public class Product {
         this.status = status;
     }
 
+    public void changeStock(int quantity) {
+        if (this.stock - quantity < 0) {
+            throw new RuntimeException("재고가 부족합니다.");
+        }
+        this.stock -= quantity;
+    }
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/repository/OrderRepository.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/repository/OrderRepository.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
-    List<Order> findByUserId(long userId);
-
     List<Order> findByUser(User user);
-    Optional<Order> findByIdAndUser(Long id, User user);
+    Optional<Order> findByOrderNumberAndUser(String orderNumber, User user);
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/repository/PaymentRepository.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.codeisevenlycooked.evenly.repository;
+import com.codeisevenlycooked.evenly.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    List<Payment> findByOrderId(Long orderId);
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
@@ -39,7 +39,6 @@ public class OrderService {
         );
 
         BigDecimal totalPrice = BigDecimal.ZERO;
-        List<OrderItemResponseDto> orderItemResponses = new ArrayList<>();
 
         for (OrderItemDto itemDto : requestDto.getOrderItems()) {
             Product product = productRepository.findById(itemDto.getProductId())

--- a/src/main/java/com/codeisevenlycooked/evenly/service/PaymentService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/PaymentService.java
@@ -30,6 +30,12 @@ public class PaymentService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new RuntimeException("주문을 찾을 수 없습니다."));
 
+        List<Payment> existingPayments = paymentRepository.findByOrderId(orderId);
+
+        if (!existingPayments.isEmpty() && "SUCCESS".equals(existingPayments.get(0).getStatus())) {
+            throw new RuntimeException("이 주문은 이미 결제 완료되었습니다.");
+        }
+
         BigDecimal amount = order.getTotalPrice();
         String paymentMethod = order.getPaymentMethod();
 

--- a/src/main/java/com/codeisevenlycooked/evenly/service/PaymentService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/PaymentService.java
@@ -1,0 +1,71 @@
+package com.codeisevenlycooked.evenly.service;
+import com.codeisevenlycooked.evenly.entity.*;
+import com.codeisevenlycooked.evenly.repository.OrderRepository;
+import com.codeisevenlycooked.evenly.repository.PaymentRepository;
+import com.codeisevenlycooked.evenly.repository.ProductRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+public class PaymentService {
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
+
+    public PaymentService(PaymentRepository paymentRepository, OrderRepository orderRepository, ProductRepository productRepository) {
+        this.paymentRepository = paymentRepository;
+        this.orderRepository = orderRepository;
+        this.productRepository = productRepository;
+    }
+
+    public boolean processPayment(Long orderId) {
+
+        boolean isPaymentSuccess = Math.random() < 0.95;
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new RuntimeException("주문을 찾을 수 없습니다."));
+
+        BigDecimal amount = order.getTotalPrice();
+        String paymentMethod = order.getPaymentMethod();
+
+       Payment payment = new Payment(
+               amount,
+               paymentMethod,
+               isPaymentSuccess ? "SUCCESS" : "FAILED",
+               LocalDateTime.now(),
+               order
+       );
+
+       paymentRepository.save(payment);
+
+       if (isPaymentSuccess) {
+           handleSuccessfulPayment(order);
+       } else {
+           handlePaymentFailure(payment);
+       }
+
+       return isPaymentSuccess;
+    }
+
+    private void handleSuccessfulPayment(Order order) {
+
+        order.changeStatus(OrderStatus.PENDING);
+        orderRepository.save(order);
+
+        for (OrderItem orderItem : order.getOrderItems()) {
+            Product product = orderItem.getProduct();
+
+            product.changeStock(orderItem.getQuantity());
+            productRepository.save(product);
+        }
+    }
+
+    private void handlePaymentFailure(Payment payment) {
+    }
+
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/service/PaymentService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/PaymentService.java
@@ -36,26 +36,26 @@ public class PaymentService {
             throw new RuntimeException("이 주문은 이미 결제 완료되었습니다.");
         }
 
+        if(!isPaymentSuccess) {
+            handlePaymentFailure(order);
+            return false;
+        }
+
         BigDecimal amount = order.getTotalPrice();
         String paymentMethod = order.getPaymentMethod();
 
-       Payment payment = new Payment(
-               amount,
-               paymentMethod,
-               isPaymentSuccess ? "SUCCESS" : "FAILED",
-               LocalDateTime.now(),
-               order
-       );
+        Payment payment = new Payment(
+                amount,
+                paymentMethod,
+                "SUCCESS",
+                LocalDateTime.now(),
+                order
+        );
 
-       paymentRepository.save(payment);
+        paymentRepository.save(payment);
 
-       if (isPaymentSuccess) {
-           handleSuccessfulPayment(order);
-       } else {
-           handlePaymentFailure(payment);
-       }
-
-       return isPaymentSuccess;
+        handleSuccessfulPayment(order);
+        return true;
     }
 
     private void handleSuccessfulPayment(Order order) {
@@ -71,7 +71,7 @@ public class PaymentService {
         }
     }
 
-    private void handlePaymentFailure(Payment payment) {
+    private void handlePaymentFailure(Order order) {
     }
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feat/payment -> dev

### 변경 사항
- 결제 기능 추가로 주문 상태(Order Status enum에 PAYMENT_PENDING 추가)
- 결제 기능 구현(실제 결제 되는 것이 아닌 성공, 실패 여부 반환, 0.95 확률로 성공, 또는 실패가 랜덤으로 반환)
    - 결제 실패시 결제 정보 DB에 저장되지 않음.
    - 결제 성공시 결제 정보 저장, 재고 변경, 주문 상태 변경(PAYMENT_PENDING -> PENDING)
    - 주문 결제 후 해당 주문 재 결제 시 예외 발생(RuntimeEx)
- 주문 기능에서 주문 번호 필드 추가 -> 주문 상세 조회시 주문 id 대신 주문 번호 사용

### 테스트 결과
![image](https://github.com/user-attachments/assets/81455b6e-41a9-4764-91a0-a07f9b0184dd)
![image](https://github.com/user-attachments/assets/9789065e-068f-4926-a218-0d215c46039e)
![image](https://github.com/user-attachments/assets/63ffba41-983b-4e4d-932f-93fc3dbe5171)

