### PR TITLE
관리자 주문 관리 기능 구현

### DIFF
--- a/src/main/java/com/codeisevenlycooked/evenly/controller/AdminOrderController.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/controller/AdminOrderController.java
@@ -1,0 +1,43 @@
+package com.codeisevenlycooked.evenly.controller;
+
+import com.codeisevenlycooked.evenly.dto.AdminListDto;
+import com.codeisevenlycooked.evenly.service.OrderService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/admin/orders")
+public class AdminOrderController {
+
+    private final OrderService orderService;
+
+    public AdminOrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("orders", orderService.getAllOrdersAdmin());
+        return "admin/orders";
+    }
+
+    @GetMapping("/{id}/edit")
+    public String editForm(@PathVariable Long id, Model model) {
+        model.addAttribute("order", orderService.getOrderAdmin(id));
+        return "admin/order-form";
+    }
+
+    @PostMapping("/{id}/edit")
+    public String updateOrder(@PathVariable Long id, @ModelAttribute AdminListDto adminListDto){
+        orderService.updateOrderAdmin(id,adminListDto);
+        return "redirect:/admin/orders";
+    }
+
+    @PostMapping("/{id}/cancel")
+    public String cancelOrder(@PathVariable Long id){
+        orderService.deleteOrderAdmin(id);
+        return "redirect:/admin/orders";
+    }
+
+}

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/AdminListDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/AdminListDto.java
@@ -16,4 +16,30 @@ public class AdminListDto {
     private BigDecimal totalPrice;
     private OrderStatus status;
     private LocalDateTime createAt;
+
+    private String receiverName;
+    private String address;
+    private String mobile;
+    private String deliveryMessage;
+    private PaymentMethod paymentMethod;
+
+    private List<OrderItem> orderItems;
+
+    public AdminListDto(Order order) {
+        this.id = order.getId();
+        this.orderNumber = order.getOrderNumber();
+        this.userId = order.getUser().getUserId();
+        this.totalPrice = order.getTotalPrice();
+        this.status = order.getStatus();
+        this.createAt = order.getCreatedAt();
+
+        this.receiverName = order.getReceiverName();
+        this.address = order.getAddress();
+        this.mobile = order.getMobile();
+        this.deliveryMessage = order.getDeliveryMessage();
+        this.paymentMethod = order.getPaymentMethod();
+        this.orderItems = order.getOrderItems();
+    }
+
+
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/dto/AdminListDto.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/dto/AdminListDto.java
@@ -1,14 +1,18 @@
 package com.codeisevenlycooked.evenly.dto;
 
+import com.codeisevenlycooked.evenly.entity.Order;
+import com.codeisevenlycooked.evenly.entity.OrderItem;
 import com.codeisevenlycooked.evenly.entity.OrderStatus;
-import lombok.Getter;
-import lombok.Setter;
+import com.codeisevenlycooked.evenly.entity.PaymentMethod;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class AdminListDto {
     private Long id;
     private String orderNumber;

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/Order.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/Order.java
@@ -1,10 +1,7 @@
 package com.codeisevenlycooked.evenly.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -13,7 +10,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "orders")
-@Getter
+@Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder(toBuilder = true)

--- a/src/main/java/com/codeisevenlycooked/evenly/entity/OrderStatus.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/entity/OrderStatus.java
@@ -5,5 +5,6 @@ public enum OrderStatus {
     PENDING,
     SHIPPED,
     DELIVERED,
-    GOOD
+    GOOD,
+    CANCELLED
 }

--- a/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
+++ b/src/main/java/com/codeisevenlycooked/evenly/service/OrderService.java
@@ -6,6 +6,7 @@ import com.codeisevenlycooked.evenly.repository.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -13,7 +14,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -186,6 +187,8 @@ public class OrderService {
                 ))
                 .toList();
 
+        log.info("Order items: {}", orderItems);
+
         OrderCreationResponseDto orderCreationResponseDto = new OrderCreationResponseDto(
                 order.getId(),
                 orderItems,
@@ -238,4 +241,47 @@ public class OrderService {
             }
         }
     }
+
+    /*
+    * admin
+    * */
+
+    /* 전체 주문 조회 */
+    @Transactional
+    public List<AdminListDto> getAllOrdersAdmin() {
+        return orderRepository.findAll(Sort.by(Sort.Direction.ASC, "createdAt"))
+                .stream().map(AdminListDto::new)
+                .collect(Collectors.toList());
+    }
+
+    /* 단일 주문 조회 */
+    @Transactional
+    public AdminListDto getOrderAdmin(Long id) {
+        Order order = orderRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 주문 내역이 없습니다."));
+        return new AdminListDto(order);
+    }
+
+    /* 수정 */
+    @Transactional
+    public void updateOrderAdmin(Long id, AdminListDto adminListDto) {
+        Order order = orderRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 주문 내역이 없습니다."));
+
+        order.setStatus(adminListDto.getStatus());
+        order.setReceiverName(adminListDto.getReceiverName());
+        order.setAddress(adminListDto.getAddress());
+        order.setMobile(adminListDto.getMobile());
+        order.setDeliveryMessage(adminListDto.getDeliveryMessage());
+        order.setPaymentMethod(adminListDto.getPaymentMethod());
+    }
+
+    /* 삭제 */
+    @Transactional
+    public void deleteOrderAdmin(Long id) {
+        Order order = orderRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 주문 내역이 없습니다."));
+        orderRepository.delete(order);
+    }
+
 }

--- a/src/main/resources/templates/admin/order-form.html
+++ b/src/main/resources/templates/admin/order-form.html
@@ -23,7 +23,7 @@
 
       <div class="mb-3">
         <label class="form-label">총 가격</label>
-        <input type="text" class="form-control" th:field="*{totalPrice}" disabled>
+        <input type="text" class="form-control" th:value="${#numbers.formatDecimal(order.totalPrice, 1, 'COMMA', 0, 'POINT')}" disabled>
       </div>
 
       <div class="mb-3">
@@ -78,9 +78,9 @@
           </thead>
           <tbody>
           <tr th:each="item : ${order.orderItems}">
-            <td th:text="${item.productName}"></td>
+            <td th:text="${item.product.name}"></td>
             <td th:text="${item.quantity}"></td>
-            <td th:text="${#numbers.formatDecimal(item.price, 0, 'COMMA')}"></td>
+            <td th:text="${#numbers.formatDecimal(order.totalPrice, 1, 'COMMA', 0, 'POINT')}"></td>
           </tr>
           </tbody>
         </table>

--- a/src/main/resources/templates/admin/orders.html
+++ b/src/main/resources/templates/admin/orders.html
@@ -23,6 +23,11 @@
       </tr>
       </thead>
       <tbody>
+
+      <tr th:if="${orders.empty}">
+        <td colspan="7" class="text-center">주문 내역이 없습니다.</td>
+      </tr>
+      
       <tr th:each="order : ${orders}">
         <td th:text="${order.id}"></td>
         <td th:text="${order.orderNumber}"></td>

--- a/src/main/resources/templates/admin/orders.html
+++ b/src/main/resources/templates/admin/orders.html
@@ -27,7 +27,7 @@
         <td th:text="${order.id}"></td>
         <td th:text="${order.orderNumber}"></td>
         <td th:text="${order.userId}"></td>
-        <td th:text="${#numbers.formatDecimal(order.totalPrice, 0, 'COMMA')}"></td> <!-- 가격을 쉼표 형식으로 출력 -->
+        <td th:text="${#numbers.formatDecimal(order.totalPrice, 1, 'COMMA', 0, 'POINT')}"></td> <!-- 가격을 쉼표 형식으로 출력 -->
         <td th:text="${order.status}"></td>
         <td th:text="${#temporals.format(order.createAt, 'yyyy-MM-dd HH:mm:ss')}"></td> <!-- 날짜 형식 지정 -->
         <td>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/admin/order -> dev

### 변경 사항
- 관리자 주문 목록 조회, 수정, 삭제 기능을 구현하였습니다.
- 주문 상태(Status)에 **취소** 를 추가하였습니다.
- 주문이 없을 경우 '주문 내역이 없습니다' 메시지를 표시하도록 설정했습니다.

### 테스트 결과



### 🟡 **현재 목록 조회 결과 (포스트맨)**
![스크린샷 2025-03-28 오후 1 38 17](https://github.com/user-attachments/assets/66d45311-30d9-4b44-a5e2-3cd67f42a6a0)
### 🟡 **관리자 주문관리 List** (동일한 주문이 들어와있음)
![스크린샷 2025-03-28 오후 1 38 43](https://github.com/user-attachments/assets/5a9b2520-1979-4078-ad09-77f04cae7153)



### 🟡 **수정폼에 들어왔을때 (DELIVERED -> SHIPPED 변경)**
![스크린샷 2025-03-28 오후 1 40 03](https://github.com/user-attachments/assets/336870e5-7f44-429e-b8e7-263c39f6cd37)
**[ 변경 된 화면 ]**
![스크린샷 2025-03-28 오후 1 40 21](https://github.com/user-attachments/assets/acd484e7-e3bf-4763-8e94-2a6da967d013)

### 🟡 **취소 버튼 클릭 시 출력되는 화면**
![스크린샷 2025-03-28 오후 1 41 04](https://github.com/user-attachments/assets/d14be834-761f-4fec-b0a2-a638f02183f9)


### 🟡 **취소 후 현재 주문 목록 조회 시 (포스트맨)**
![스크린샷 2025-03-28 오후 1 41 29](https://github.com/user-attachments/assets/e84bb578-5c23-45e1-ac9a-cd959c60cfff)
 
